### PR TITLE
Initial work on Mac patching

### DIFF
--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -58,9 +58,9 @@ def _hash_asset(args: Tuple[Path, Path]) -> Tuple[Path, str, int]:
         bundle_name = source_path.stem
         # Guess the executable path - we could get the exact name if we could unpack the Info.plist
         # in a cross platform way.
-        source_path = source_path.joinpath(Path("Contents/MacOS/" + bundle_name))
+        source_path = source_path.joinpath(Path("Contents/MacOS",  bundle_name))
     with source_path.open("rb") as in_stream:
-         _io_loop(in_stream, h.update)
+        _io_loop(in_stream, h.update)
     return server_path, h.hexdigest(), source_path.stat().st_size
 
 def _compare_files(newFile: Path, prevFile: Path, *, key=None) -> bool:

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -37,7 +37,10 @@ def _compress_asset(source_path: Path, output_path: Path):
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if source_path.is_dir():
         with tarfile.TarFile.open(output_path, "w:gz") as tar:
-            tar.add(source_path,  arcname="")
+            tar.add(source_path, arcname="")
+        with output_path.open("rb") as in_stream:
+            h = hashlib.md5()
+            _io_loop(in_stream, h.update)
         h = hashlib.md5(open(output_path,'rb').read())
         return h.hexdigest(), output_path.stat().st_size
     with source_path.open("rb") as in_stream:

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -41,7 +41,6 @@ def _compress_asset(source_path: Path, output_path: Path):
         with output_path.open("rb") as in_stream:
             h = hashlib.md5()
             _io_loop(in_stream, h.update)
-        h = hashlib.md5(open(output_path,'rb').read())
         return h.hexdigest(), output_path.stat().st_size
     with source_path.open("rb") as in_stream:
         with gzip.open(output_path, "wb") as gz_stream:
@@ -126,8 +125,7 @@ def compress_dirty_assets(manifests: Dict[str, Set[Path]], cached_assets: Dict[P
         for server_path, staged_asset, source_asset, cached_asset in asset_iter:
             assert server_path.parent.name
 
-            if source_asset.source_path.is_dir():
-                staged_asset.flags |= ManifestFlags.bundle
+            if staged_asset.flags & ManifestFlags.bundle:
                 asset_output_path = output_path.joinpath(server_path).with_suffix(f"{server_path.suffix}.tgz")
             else:
                 asset_output_path = output_path.joinpath(server_path).with_suffix(f"{server_path.suffix}.gz")

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -33,11 +33,16 @@ import manifest
 
 _BUFFER_SIZE = 10 * 1024 * 1024
 
+def _add_to_tar_archive(info: tarfile.TarInfo):
+    info.mode = 0o777
+    return info
+
 def _compress_asset(source_path: Path, output_path: Path):
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if source_path.is_dir():
         with tarfile.TarFile.open(output_path, "w:gz") as tar:
-            tar.add(source_path, arcname="")
+            tar.gettarinfo(source_path, arcname="")
+            tar.add(source_path, arcname="", filter=_add_to_tar_archive)
         with output_path.open("rb") as in_stream:
             h = hashlib.md5()
             _io_loop(in_stream, h.update)

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -63,7 +63,7 @@ def _hash_asset(args: Tuple[Path, Path, bool]) -> Tuple[Path, str, int]:
         bundle_name = source_path.stem
         # Guess the executable path - we could get the exact name if we could unpack the Info.plist
         # in a cross platform way.
-        source_path = source_path.joinpath("Contents", MacOS",  bundle_name)
+        source_path = source_path.joinpath("Contents", MacOS", bundle_name)
     with source_path.open("rb") as in_stream:
         _io_loop(in_stream, h.update)
     return server_path, h.hexdigest(), source_path.stat().st_size

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -63,7 +63,7 @@ def _hash_asset(args: Tuple[Path, Path, bool]) -> Tuple[Path, str, int]:
         bundle_name = source_path.stem
         # Guess the executable path - we could get the exact name if we could unpack the Info.plist
         # in a cross platform way.
-        source_path = source_path.joinpath("Contents", MacOS", bundle_name)
+        source_path = source_path.joinpath("Contents", "MacOS", bundle_name)
     with source_path.open("rb") as in_stream:
         _io_loop(in_stream, h.update)
     return server_path, h.hexdigest(), source_path.stat().st_size

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -39,7 +39,7 @@ def _add_to_tar_archive(info: tarfile.TarInfo):
 
 def _compress_asset(source_path: Path, output_path: Path, bundle: bool):
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    if source_path.is_dir():
+    if bundle:
         with tarfile.TarFile.open(output_path, "w:gz") as tar:
             tar.gettarinfo(source_path, arcname="")
             tar.add(source_path, arcname="", filter=_add_to_tar_archive)
@@ -55,11 +55,11 @@ def _compress_asset(source_path: Path, output_path: Path, bundle: bool):
         _io_loop(in_stream, h.update)
     return h.hexdigest(), output_path.stat().st_size
 
-def _hash_asset(args: Tuple[Path, Path]) -> Tuple[Path, str, int]:
-    server_path, source_path = args
+def _hash_asset(args: Tuple[Path, Path, bool]) -> Tuple[Path, str, int]:
+    server_path, source_path, mac_app_bundle = args
     # One day, we will not use such a vulnerable hashing algo...
     h = hashlib.md5()
-    if source_path.is_dir():
+    if mac_app_bundle:
         bundle_name = source_path.stem
         # Guess the executable path - we could get the exact name if we could unpack the Info.plist
         # in a cross platform way.
@@ -305,7 +305,7 @@ def hash_staged_assets(source_assets: Dict[Path, Asset], staged_assets: Dict[Pat
                        ncpus: Optional[int] = None) -> None:
     logging.info("Hashing all staged assets...")
     with concurrent.futures.ProcessPoolExecutor(max_workers=ncpus) as executor:
-        args = ((sp, source_assets[sp].source_path) for sp, sa in staged_assets.items() if not sa.flags & ManifestFlags.consumable)
+        args = ((sp, source_assets[sp].source_path, sa.flags & ManifestFlags.bundle) for sp, sa in staged_assets.items() if not sa.flags & ManifestFlags.consumable)
         for server_path, h, sz in executor.map(_hash_asset, args, chunksize=64):
             logging.trace(f"{server_path}: {h}")
             staged_asset = staged_assets[server_path]

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -55,14 +55,12 @@ def _hash_asset(args: Tuple[Path, Path]) -> Tuple[Path, str, int]:
     # One day, we will not use such a vulnerable hashing algo...
     h = hashlib.md5()
     if source_path.is_dir():
-        for file in source_path.rglob("*"):
-            # ignore any intermediary directories
-            if not file.is_dir():
-                with file.open("rb") as in_stream:
-                    _io_loop(in_stream, h.update)
-    else:
-        with source_path.open("rb") as in_stream:
-            _io_loop(in_stream, h.update)
+        bundle_name = source_path.stem
+        # Guess the executable path - we could get the exact name if we could unpack the Info.plist
+        # in a cross platform way.
+        source_path = source_path.joinpath(Path("Contents/MacOS/" + bundle_name))
+    with source_path.open("rb") as in_stream:
+         _io_loop(in_stream, h.update)
     return server_path, h.hexdigest(), source_path.stat().st_size
 
 def _compare_files(newFile: Path, prevFile: Path, *, key=None) -> bool:

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -21,7 +21,6 @@ import gzip
 import hashlib
 import itertools
 import logging
-import os
 from pathlib import Path
 import shutil
 import tarfile
@@ -54,9 +53,10 @@ def _hash_asset(args: Tuple[Path, Path]) -> Tuple[Path, str, int]:
     # One day, we will not use such a vulnerable hashing algo...
     h = hashlib.md5()
     if source_path.is_dir():
-        for subdir, dirs, files in os.walk(source_path):
-            for f in files:
-                with Path(os.path.join(subdir, f)).open("rb") as in_stream:
+        for file in source_path.rglob("*"):
+            # ignore any intermediary directories
+            if not file.is_dir():
+                with file.open("rb") as in_stream:
                     _io_loop(in_stream, h.update)
     else:
         with source_path.open("rb") as in_stream:

--- a/urumanifest/commit.py
+++ b/urumanifest/commit.py
@@ -37,7 +37,7 @@ def _add_to_tar_archive(info: tarfile.TarInfo):
     info.mode = 0o777
     return info
 
-def _compress_asset(source_path: Path, output_path: Path):
+def _compress_asset(source_path: Path, output_path: Path, bundle: bool):
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if source_path.is_dir():
         with tarfile.TarFile.open(output_path, "w:gz") as tar:
@@ -142,7 +142,8 @@ def compress_dirty_assets(manifests: Dict[str, Set[Path]], cached_assets: Dict[P
             if staged_asset.flags & ManifestFlags.dirty or force:
                 future = executor.submit(_compress_asset,
                                          source_asset.source_path,
-                                         asset_output_path)
+                                         asset_output_path,
+                                         staged_asset.flags &  ManifestFlags.bundle)
                 future.add_done_callback(functools.partial(on_compress, staged_asset))
             else:
                 staged_asset.download_hash = cached_asset.download_hash

--- a/urumanifest/constants.py
+++ b/urumanifest/constants.py
@@ -65,6 +65,8 @@ gather_manifests = {
     "mac": _manifests(None, None, "macExternal"),
     "macInternal": _manifests("MacThinInternal", None, "MacInternal"),
     "macExternal": _manifests("MacThinExternal", None, "MacExternal"),
+    "macBundleInternal": _manifests("MacThinInternal", None, "MacInternal"),
+    "macBundleExternal": _manifests("MacThinExternal", None, "MacExternal"),
 }
 
 class _directorytuple(NamedTuple):
@@ -85,6 +87,8 @@ gather_lut = {
     "internal64": _directorytuple("", "client/windows_amd64/internal"),
     "macexternal": _directorytuple("", "client/mac/external"),
     "macinternal": _directorytuple("", "client/mac/internal"),
+    "macbundleexternal": _directorytuple("", "client/mac/external"),
+    "macbundleinternal": _directorytuple("", "client/mac/internal"),
     "mac": _directorytuple("", "client/macos_ia32/external"),
     "prereq": _directorytuple("", "dependencies/windows_ia32"),
     "prereq64": _directorytuple("", "dependencies/windows_amd64"),

--- a/urumanifest/constants.py
+++ b/urumanifest/constants.py
@@ -45,6 +45,7 @@ crypt_types = {
 
 # All gather sections that list installer prerequisites
 gather_installers = frozenset(("prereq", "prereq64"))
+mac_bundles = frozenset(("macBundleInternal", "macBundleExternal"))
 
 class _manifests(NamedTuple):
     thin: str

--- a/urumanifest/constants.py
+++ b/urumanifest/constants.py
@@ -63,8 +63,8 @@ gather_manifests = {
 
     # Legacy -- to be deleted??? -- TransGaming Cider Wrapper (macOS)
     "mac": _manifests(None, None, "macExternal"),
-    "macInternal": _manifests(None, None, "MacInternal"),
-    "macExternal": _manifests(None, None, "MacExternal"),
+    "macInternal": _manifests("MacThinInternal", None, "MacInternal"),
+    "macExternal": _manifests("MacThinExternal", None, "MacExternal"),
 }
 
 class _directorytuple(NamedTuple):

--- a/urumanifest/constants.py
+++ b/urumanifest/constants.py
@@ -62,8 +62,7 @@ gather_manifests = {
     "prereq64": _manifests(None, "DependencyPatcher64", None),
 
     # Legacy -- to be deleted??? -- TransGaming Cider Wrapper (macOS)
-    "mac": _manifests(None, None, "macExternal")
-    ,
+    "mac": _manifests(None, None, "macExternal"),
     "macInternal": _manifests(None, None, "MacInternal"),
     "macExternal": _manifests(None, None, "MacExternal"),
 }

--- a/urumanifest/constants.py
+++ b/urumanifest/constants.py
@@ -62,7 +62,10 @@ gather_manifests = {
     "prereq64": _manifests(None, "DependencyPatcher64", None),
 
     # Legacy -- to be deleted??? -- TransGaming Cider Wrapper (macOS)
-    "mac": _manifests(None, None, "macExternal"),
+    "mac": _manifests(None, None, "macExternal")
+    ,
+    "macInternal": _manifests(None, None, "MacInternal"),
+    "macExternal": _manifests(None, None, "MacExternal"),
 }
 
 class _directorytuple(NamedTuple):
@@ -81,6 +84,8 @@ gather_lut = {
     "external64": _directorytuple("", "client/windows_amd64/external"),
     "internal": _directorytuple("", "client/windows_ia32/internal"),
     "internal64": _directorytuple("", "client/windows_amd64/internal"),
+    "macexternal": _directorytuple("", "client/mac/external"),
+    "macinternal": _directorytuple("", "client/mac/internal"),
     "mac": _directorytuple("", "client/macos_ia32/external"),
     "prereq": _directorytuple("", "dependencies/windows_ia32"),
     "prereq64": _directorytuple("", "dependencies/windows_amd64"),
@@ -100,6 +105,7 @@ class ManifestFlags(enum.IntFlag):
     sound_cache_stereo = (1<<2)
     file_gzipped = (1<<3)
     installer = (1<<4)
+    bundle = (1<<5)
 
     # Internal flags
     python_file_mod = (1<<16)
@@ -153,4 +159,6 @@ workflow_lut = {
     "plasma-windows-x64-external-release": "external64",
     "plasma-windows-x86-internal-release": "internal",
     "plasma-windows-x64-internal-release": "internal64",
+    "plasma-macos-x64-internal-release": "macInternal",
+    "plasma-macos-x64-external-release": "macExternal",
 }

--- a/urumanifest/dependencies.py
+++ b/urumanifest/dependencies.py
@@ -191,7 +191,7 @@ def find_client_dependencies(source_assets: Dict[Path, Asset],
 
     def track_manifest_dependency(client_path: Path, server_path: Path, category: str, manifest_names):
         flags = ManifestFlags.installer if category in gather_installers else 0
-        flags |= ManifestFlags.bundle if client_path.suffix == ".app" else 0
+        flags |= ManifestFlags.bundle if category in mac_bundles else 0
         track_dependency(client_path, server_path, flags)
         for name in manifest_names:
             if name:

--- a/urumanifest/dependencies.py
+++ b/urumanifest/dependencies.py
@@ -191,6 +191,7 @@ def find_client_dependencies(source_assets: Dict[Path, Asset],
 
     def track_manifest_dependency(client_path: Path, server_path: Path, category: str, manifest_names):
         flags = ManifestFlags.installer if category in gather_installers else 0
+        flags |= ManifestFlags.bundle if client_path.is_dir() else 0
         track_dependency(client_path, server_path, flags)
         for name in manifest_names:
             if name:

--- a/urumanifest/dependencies.py
+++ b/urumanifest/dependencies.py
@@ -191,7 +191,7 @@ def find_client_dependencies(source_assets: Dict[Path, Asset],
 
     def track_manifest_dependency(client_path: Path, server_path: Path, category: str, manifest_names):
         flags = ManifestFlags.installer if category in gather_installers else 0
-        flags |= ManifestFlags.bundle if client_path.is_dir() else 0
+        flags |= ManifestFlags.bundle if client_path.suffix == ".app" else 0
         track_dependency(client_path, server_path, flags)
         for name in manifest_names:
             if name:

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -21,6 +21,7 @@ import itertools
 import logging
 import math
 import json
+import os
 from pathlib import Path, PurePosixPath
 import requests
 import subprocess

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -392,8 +392,8 @@ def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, 
                         yield ArtifactInfo(path=member_path.name, zipinfo=i, name=member_path.name)
                     elif is_mac_app_bundle and not i.is_dir():
                         # remove "client/"
-                        path = i.filename[len(client_folder_name)+1:]
-                        yield ArtifactInfo(path=Path(path), zipinfo=i, name=member_path.parts[1])
+                        path = member_path.relative_to(client_folder_name)
+                        yield ArtifactInfo(path=path.name, zipinfo=i, name=member_path.parts[1])
 
 
 

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -382,7 +382,7 @@ def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, 
                 if len(member_path.parts) >=  2 and member_path.parts[0] == "client":
                     is_mac_app_bundle = member_path.parts[1].endswith(".app")
                     if not i.is_dir() and len(member_path.parts) ==  2:
-                        yield (Path(i.filename).name, i, Path(i.filename).name)
+                        yield (member_path.name, i, member_path.name)
                     elif is_mac_app_bundle and not i.is_dir():
                         path = i.filename[7:]
                         yield (Path(path), i, member_path.parts[1])

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -369,7 +369,10 @@ def _update_artifacts(staging_path: Path, database: _WorkflowDatabase, repo: str
     database.current_sha = rev
     database.valid = True
 
-ArtifactInfo = namedtuple('ArtifactInfo', 'path zipinfo name')
+class ArtifactInfo(NamedTuple):
+    path: Path
+    zipinfo: zipfile.ZipInfo
+    name: str
 
 def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, name: str, artifact: tempfile.NamedTemporaryFile):
     logging.debug(f"Decompressing {name}.zip from {artifact.name}")
@@ -415,7 +418,7 @@ def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, 
 def _unpack_member(output_path: Path, output_subpath: Path, archive: zipfile.ZipFile, info: zipfile.ZipInfo):
     with archive.open(info, "r") as infile:
         full_path = output_path.joinpath(output_subpath)
-        Path(os.path.dirname(full_path)).mkdir(parents=True, exist_ok=True)
+        full_path.parent.mkdir(parents=True, exist_ok=True)
         with full_path.open("wb") as outfile:
             block = 1024 * 8
             while True:

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -380,12 +380,14 @@ def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, 
         def iter_client_dir():
             for i in archive.infolist():
                 member_path = PurePosixPath(i.filename)
-                if len(member_path.parts) >=  2 and member_path.parts[0] == "client":
+                client_folder_name = "client"
+                if len(member_path.parts) >=  2 and member_path.parts[0] == client_folder_name:
                     is_mac_app_bundle = member_path.parts[1].endswith(".app")
                     if not i.is_dir() and len(member_path.parts) ==  2:
                         yield (member_path.name, i, member_path.name)
                     elif is_mac_app_bundle and not i.is_dir():
-                        path = i.filename[7:]
+                        # remove "client/"
+                        path = i.filename[len(client_folder_name)+1:]
                         yield (Path(path), i, member_path.parts[1])
 
 

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -409,7 +409,8 @@ def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, 
                 _unpack_member(output_path, info.path, archive, info.zipinfo)
 
         gather_key = workflow_lut[name]
-        gather_package = { gather_key: [i.name for i in desired_members] }
+        # Bundles might add multiple members with the same name - clean that up
+        gather_package = { gather_key: list(set([i.name for i in desired_members])) }
         with output_path.joinpath("control.json").open("w") as fp:
             json.dump(gather_package, fp, indent=2)
 

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -414,7 +414,7 @@ def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, 
         # Bundles might add multiple members with the same name - clean that up
         desired_bundles = list(set([i.name for i in list(filter(lambda x: x.bundle == True, desired_members))]))
         gather_package = { gather_key: desired_files }
-        if len(desired_bundles) > 0:
+        if desired_bundles:
             key = "macBundleExternal" if gather_key == "macExternal" else "macBundleInternal"
             gather_package[key] = desired_bundles
         with output_path.joinpath("control.json").open("w") as fp:

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -375,6 +375,7 @@ class ArtifactInfo(NamedTuple):
     name: str
     bundle: bool = False
 
+
 def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, name: str, artifact: tempfile.NamedTemporaryFile):
     logging.debug(f"Decompressing {name}.zip from {artifact.name}")
 

--- a/urumanifest/github.py
+++ b/urumanifest/github.py
@@ -393,7 +393,7 @@ def _unpack_artifact(staging_path: Path, database: _WorkflowDatabase, rev: str, 
                     elif is_mac_app_bundle and not i.is_dir():
                         # remove "client/"
                         path = member_path.relative_to(client_folder_name)
-                        yield ArtifactInfo(path=path.name, zipinfo=i, name=member_path.parts[1])
+                        yield ArtifactInfo(path=path, zipinfo=i, name=member_path.parts[1])
 
 
 


### PR DESCRIPTION
This is kind of ugly but seems to work.

I'm using tgz for the Mac app bundle in since it's a directory. That should be ok in since the Mac client is the only one that will need to look at these manifests - but it would require the client now handle the tar format.

I don't know if there is a better way that doesn't involve tar'ing. I could store as separate files but the logic starts to get more complicated at knowing what to keep and what to delete if we want to get rid of the existing bundle entirely.